### PR TITLE
Delete .gitconfig and polished makefile

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,1 +1,0 @@
-config.json

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,3 @@ dev-deps:
 
 clean:
 	go clean
-	rm -f gpb-firewalls-microservice
-
-dist-clean:
-	rm -rf pkg src bin
-
-ci-deps:


### PR DESCRIPTION
- .gitconfig is not necessary
- ci-deps makefile task is not necessary and empty
- dist-clean is also not necessary as we build with `go install` instead of `go build`
